### PR TITLE
Close KhronosGroup#126: Add in the StandardShapeFuncs shapes of zero_point_linear_quantize and min_max_linear_quantize

### DIFF
--- a/parser/cpp/include/nnef/common/shapes.h
+++ b/parser/cpp/include/nnef/common/shapes.h
@@ -991,6 +991,11 @@ namespace nnef
 		return quantize_shape(input, Shape(), max, bits);
 	}
     
+	inline Shape zero_point_linear_quantize_shape( const Shape& input, const Value& zero_point, const Value& scale, const Value& bits )
+	{
+		return quantize_shape(input, Shape(), Shape(), bits);
+	}
+
 }   // namespace nnef
 
 

--- a/parser/cpp/src/nnef.cpp
+++ b/parser/cpp/src/nnef.cpp
@@ -561,6 +561,8 @@ namespace nnef
         
         { "linear_quantize", make_shape_func(linear_quantize_shape) },
         { "logarithmic_quantize", make_shape_func(logarithmic_quantize_shape) },
+        { "min_max_linear_quantize", make_shape_func(linear_quantize_shape) },
+        { "zero_point_linear_quantize", make_shape_func(zero_point_linear_quantize_shape) },
         
         { "add", make_shape_func(binary_shape) },
         { "sub", make_shape_func(binary_shape) },


### PR DESCRIPTION
Close KhronosGroup#126: Add in the StandardShapeFuncs shapes of zero_point_linear_quantize and min_max_linear_quantize