### PR TITLE
Updated collections import to be compatible with Python 3.10 and newer

### DIFF
--- a/nnef_tools/model/graph.py
+++ b/nnef_tools/model/graph.py
@@ -14,7 +14,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-from collections import Sequence
+from collections.abc import Sequence
 from functools import reduce
 
 import six


### PR DESCRIPTION
Closes #154 

See issue #154 for more information. This PR updates collections import to be compatible with Python 3.10 and newer.