### PR TITLE
Fixed some build issues and compiler warnings on Windows

### DIFF
--- a/skriptnd-pyproject/skriptnd/cpp/CMakeLists.txt
+++ b/skriptnd-pyproject/skriptnd/cpp/CMakeLists.txt
@@ -68,6 +68,10 @@ target_include_directories(${PROJECT_NAME}
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX _d)
 
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:preprocessor)
+endif()
+
 target_link_libraries(${PROJECT_NAME})
 
 # install the library

--- a/skriptnd-pyproject/skriptnd/cpp/CMakeLists.txt
+++ b/skriptnd-pyproject/skriptnd/cpp/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX _d)
 
 if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:preprocessor)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:preprocessor /bigobj)
 endif()
 
 target_link_libraries(${PROJECT_NAME})

--- a/skriptnd-pyproject/skriptnd/cpp/CMakeLists.txt
+++ b/skriptnd-pyproject/skriptnd/cpp/CMakeLists.txt
@@ -69,7 +69,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX _d)
 
 if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:preprocessor /bigobj)
+    target_compile_options(${PROJECT_NAME} PRIVATE 
+        /Zc:preprocessor
+        $<$<CONFIG:Debug>:/bigobj>)
 endif()
 
 target_link_libraries(${PROJECT_NAME})

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/evaluation.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/evaluation.h
@@ -2463,6 +2463,9 @@ namespace sknd
                     return Typename::Type;
                 }
             }
+
+            assert(false);
+            return Typename::Type;
         }
         
         static Result<bool> eval_null( const Expr& expr, const Dict<Symbol>& symbols )

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/model.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/model.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <forward_list>
 #include <iomanip>
+#include <functional>
 #include "types.h"
 #include "either.h"
 #include "packable.h"

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
@@ -1468,6 +1468,10 @@ namespace sknd
                 auto i = dtype() == Typename::Real ? ValueExpr((real_t)idx) : ValueExpr((int_t)idx);
                 return range.first + i * range.stride;
             }
+            default:
+            {
+                return *this;
+            }
         }
     }
 

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
@@ -1566,6 +1566,10 @@ namespace sknd
                 auto range = as_range();
                 return range.first + idx * range.stride;
             }
+            default:
+            {
+                return *this;
+            }
         }
     }
 

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
@@ -1376,6 +1376,7 @@ namespace sknd
                 return ceil_div(range.last - range.first, range.stride);
             }
         }
+        return nullptr;
     }
 
     inline ValueExpr ValueExpr::at( const size_t idx ) const

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <limits>
 #include <cmath>
+#include <unordered_map>
 
 
 namespace sknd

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
@@ -1262,6 +1262,10 @@ namespace sknd
                 auto range = as_range();
                 return !range.first.is_literal() || !range.last.is_literal() || !range.stride.is_literal();
             }
+            default:
+            {
+                return false;
+            }
         }
     }
 

--- a/skriptnd-pyproject/skriptnd/cpp/include/frontend/lexer.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/frontend/lexer.h
@@ -525,6 +525,7 @@ namespace sknd
                     return read_operator();
                 }
                 case Category::Invalid:
+                default:
                 {
                     return Error(_position, "illegal symbol '%c'", (char)_input.peek());
                 }

--- a/skriptnd-pyproject/skriptnd/cpp/include/frontend/parser.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/frontend/parser.h
@@ -17,6 +17,10 @@
 #ifndef _SKND_PARSER_H_
 #define _SKND_PARSER_H_
 
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#endif
+
 #include "lexer.h"
 #include "operator.h"
 #include <algorithm>

--- a/skriptnd-pyproject/skriptnd/cpp/include/frontend/symbolic.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/frontend/symbolic.h
@@ -787,6 +787,9 @@ namespace sknd
                     return Typename::Type;
                 }
             }
+
+            assert(false);
+            return Typename::Type;
         }
         
     private:

--- a/skriptnd-pyproject/skriptnd/cpp/include/frontend/typing.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/frontend/typing.h
@@ -2289,6 +2289,8 @@ namespace sknd
                     return eval_type(as_substitute(expr), decls, flags);
                 }
             }
+
+            return Error(expr.position, "unknown expression type '%s'");
         }
         
         static Result<Type> eval_type( const LiteralExpr& literal, const Dict<Declaration>& decls )

--- a/skriptnd-pyproject/skriptnd/cpp/include/frontend/typing.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/frontend/typing.h
@@ -3268,6 +3268,8 @@ namespace sknd
                     return pack_rank;
                 }
             }
+
+            return Error(expr.position, "unknown expression type");
         }
         
         static Result<Shared<Expr>> eval_items_rank( const std::vector<Shared<Expr>>& items, const Dict<Declaration>& decls,


### PR DESCRIPTION
- Added some missing includes
- Updated the compiler options in CMakeLists.txt when using MSVC
  - Added `/Zc:preprocessor` to handle the complex macros in `core/result.h`
  - Added `/bigobj` when building in Debug mode.
- Fixed some compiler warnings regarding missing return statements.