### PR TITLE
Include <cstdint> into all files using `uint32_t` and friends

### DIFF
--- a/nnef-pyproject/nnef/cpp/include/nnef/common/binary.h
+++ b/nnef-pyproject/nnef/cpp/include/nnef/common/binary.h
@@ -18,6 +18,7 @@
 #define _NNEF_BINARY_H_
 
 #include "error.h"
+#include <cstdint>
 #include <functional>
 #include <algorithm>
 #include <numeric>

--- a/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/composer/valuexpr.h
@@ -21,6 +21,7 @@
 #include "variant.h"
 #include "function.h"
 #include "tensorref.h"
+#include <cstdint>
 #include <optional>
 #include <sstream>
 #include <cassert>

--- a/skriptnd-pyproject/skriptnd/cpp/include/core/binary.h
+++ b/skriptnd-pyproject/skriptnd/cpp/include/core/binary.h
@@ -18,6 +18,7 @@
 #define _SKND_BINARY_H_
 
 #include "error.h"
+#include <cstdint>
 #include <functional>
 #include <algorithm>
 #include <numeric>


### PR DESCRIPTION
This fixes compilation with clang on Linux with libstdc++.

I don't know whether `<cstdint>` or `<stdint.h>` is preferred.